### PR TITLE
Lsf model

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ python -m linefits.linefits_singleepoch linefits.config [file or list]
 As seen in the config file:
 - master_peak_locs: This should be a npy file with a nested ordered dictionary. The first level is the spectral order (labeled by its index in the fits file), and the second level is the index of the line within that order. The value itself is an estimate of the line location in the 1-d spectrum, in units of pixels. This is used to label and locate the windows for each line fit.
 - master_wavecal: This is a fits file of the same form as the spectrum, with accurate wavelengths in the relevant extensions.
+
+LSF Implementation
+----
+
+In order to run LSF fitting, set the fit funtion in the config file to 'LSF' This requires additional files that can be found in https://github.com/AshutoshJoshiTIFR/NEIDLSFMODEL 
+Specifically, you will need: 
+- NEID_LSFMODEL_{fiber you want to use}
+- NeidLsf.py and required local library 

--- a/README.md
+++ b/README.md
@@ -24,4 +24,14 @@ LSF Implementation
 In order to run LSF fitting, set the fit funtion in the config file to 'LSF' This requires additional files that can be found in https://github.com/AshutoshJoshiTIFR/NEIDLSFMODEL 
 Specifically, you will need: 
 - NEID_LSFMODEL_{fiber you want to use}
-- NeidLsf.py and required local library 
+- NeidLsf.py and all required local libraries
+
+#### Etalon fitting under 'LSF'
+The Etalon does not follow LSF behavior exactly, so instead there is the option to input peak profiles as a dictionary of peaks. If config settings are set to 
+>Source = 'Etalon'
+
+and 
+>fit_function = 'LSF'
+
+The program will look for a local file containing those peak profiles and attempt to fit them, they must be alligned one-to-one with the indexing used for the peak location file under the config option
+>master_peak_locs

--- a/linefits/fitLib.py
+++ b/linefits/fitLib.py
@@ -14,6 +14,8 @@ import datetime
 import astropy
 import astropy.time
 from packaging import version
+import pickle
+import matplotlib.pyplot as plt
 try: #Packages needed for LSF 
     from NeidLsf import *
     import pickle

--- a/linefits/fitLib.py
+++ b/linefits/fitLib.py
@@ -92,7 +92,7 @@ def getLsf(echelle_order, pixel_idx, numPix=0,fiber='CAL',src = 'LFC',peakNum = 
         #Experimimental; provide a npy file containing an oDict in shape
         #(order,peakNumber,300) where the final dimension is the y values 
         #For an evenly sampled peak profile for each peak
-        LSF_MODEL_ET = np.load('EtalonPeakProfiles.npy',allow_pickle=1)[()]
+        LSF_MODEL_ET = np.load('PeakProfiles.npy',allow_pickle=1)[()]
         pixels = np.linspace(-6,6,300)
         lsf = LSF_MODEL_ET[echelle_order][peakNum]
     else:

--- a/linefits/fitLib.py
+++ b/linefits/fitLib.py
@@ -509,12 +509,13 @@ def fitProfile(inp_x, inp_y, fit_center_in, order, fit_width=8, sigma=None,
         # Apply best-fit transform
         xin_trans = (popt[1]*xin) + popt[0]
         yin_trans = yin
-        interp = scipy.interpolate.interp1d(xRef, yRef, kind='cubic', bounds_error=False, fill_value=0)
+        #interp = scipy.interpolate.interp1d(xRef, yRef, kind='cubic', bounds_error=False, fill_value=0)
         #yRef_interp = interp(xin_trans)
         yRef_interp = np.interp(xin_trans,xRef,yRef)
         # Compute residuals and SNR
         residuals = yin_trans - yRef_interp
         resid_std = np.nanstd(residuals)
+        # We normalize to 1, so signal/noise := ~1/noise
         snr_est = 1 / resid_std if resid_std > 0 else np.nan
         
         # Estimate effective width in pixels
@@ -532,11 +533,11 @@ def fitProfile(inp_x, inp_y, fit_center_in, order, fit_width=8, sigma=None,
         
         # Result values
         centroid = popt[0]
-        
+        sigma = effective_width_pix / 16
         retval = {
             'centroid': centroid,
             'e_centroid': centroid_error,
-            'sigma': popt[1],  # Just a placeholder if needed
+            'sigma': sigma,
             'e_sigma': np.nan,
             'nanflag': nanflag,
             'pcov': None,
@@ -545,7 +546,7 @@ def fitProfile(inp_x, inp_y, fit_center_in, order, fit_width=8, sigma=None,
             'function_used': func,
             'tot_counts_in_line': tot_counts_in_line,
             'fit_successful': fit_successful,
-            'scale_value': float(popt[0]),
+            'scale_value': scale_value,
             'snr_peak': snr_est
         }
         

--- a/linefits/fitLib.py
+++ b/linefits/fitLib.py
@@ -14,58 +14,87 @@ import datetime
 import astropy
 import astropy.time
 from packaging import version
-import pickle
-import matplotlib.pyplot as plt
-from NeidLsf import *
+try: #Packages needed for LSF 
+    from NeidLsf import *
+    import pickle
+except:
+    pass
 
 """ This is a library of functions that are called in the
 wavelength calibration.
 
 """
 
-def diff(x1, y1, x2, y2):
-    interp = scipy.interpolate.interp1d(x1, y1, bounds_error=False, fill_value=0)
-    y1_interp = interp(x2)
-    residuals = y1_interp - y2
-    return np.nanmean(residuals**2)
     
 def ampAndOffset(params, xin, yin, xRef, yRef):
+    '''
+    A cost evaluation function to be used in conjuntion with 
+    scipy.optimize.minimize to fit scatter plots of data to each other 
+    with paramaters from params
+
+    Paramater
+    ---------
+    params : unpackable, (2,)
+        Paramater set containing xOffset and width values to test
+    xin : array
+        Unmodified x data that is being fit to the reference data
+        Should be centered around zero
+    yin : array
+        Noramlized to 1 y data corresponding to xin
+    xRef : array
+        Reference x data 
+    yRef : array
+        Normalized to 1 y data
+
+    Returns
+    --------
+    cost : float
+        the cost of this fit calculated from the residuals
+    ''' 
     xOffset, width = params
     xin_trans = (width * xin) + xOffset
     interp = scipy.interpolate.interp1d(xin_trans, yin, kind='cubic', bounds_error=False, fill_value=0)
     yRef_interp = interp(xRef)
     residuals = yRef_interp - yRef
     cost = np.nanmean(residuals ** 2)
-    #fig = plt.figure()
-    #plt.plot(xin_trans,yin,label='yin')
-    #plt.plot(xRef,yRef,label='yRef')
-    #plt.plot(xRef,yRef_interp,label='yInterp')
-    #plt.legend()
-    #print(f'xIn{xin_trans[0]}:{xin_trans[-1]} and xRef:{xRef[0]}:{xRef[-1]}')
-    #print(f'xOff:{params[0]}  Width:{params[1]}  Cost:{cost}')
     return cost
 
 
-with open("NEID_LSFMODEL_HR_SCI", "rb") as f:
-    LSF_MODEL_SCI = NeidLSFModel(pickle.load(f))
-
-with open("NEID_LSFMODEL_HR_CAL", "rb") as f:
-    LSF_MODEL_CAL = NeidLSFModel(pickle.load(f))
-
-
-LSF_MODEL_CAL_ET = np.load('EtalonPeakProfilesCal.npy',allow_pickle=1)[()]
-
 
 def getLsf(echelle_order, pixel_idx, numPix=0,fiber='CAL',src = 'LFC',peakNum = 0): 
-    if src == 'LFC':
-        if(fiber == 'SCI'):
-            pixels, lsf = LSF_MODEL_SCI.lsf_model(echelle_order, pixel_idx)
-        elif(fiber=='CAL'):
-            pixels, lsf = LSF_MODEL_CAL.lsf_model(echelle_order, pixel_idx)
+    '''
+    Function to return the LSF prediction for a given LFC pixel, or to return the peak profile of a different source if one is provided
 
-    elif (src == 'Etalon'):
+    Paramaters:
+    ------------
+    echelle_order : int
+        Which order the profile is in
+    Pixel_inx : int
+        Which pixel to return a profile for, +- 100 pixels or so is usually fine
+    numPix : int
+        Optional resampling number, disabled at zero
+    fiber : str
+        Which instrumental fiber to return a peak for
+        typically "SCI","CAL", or "SKY"
+    src : str
+        What cal source to return a peak for, LSF only really 
+        works on LFC, so if Etalon is provided you must 
+        provide a calculated set of peak profiles 
+    peakNum : int
+        If using a dictionary of modes with peak profiles, 
+        the index of the peak profile to return
+    '''
+    if(src=='LFC'):
+        with open(f'NEID_LSFMODEL_HR_{fiber}', "rb") as f:
+            LSF_MODEL = NeidLSFModel(pickle.load(f))
+        pixels, lsf = LSF_MODEL.lsf_model(echelle_order, pixel_idx)
+    elif(src=='Etalon'):
+        #Experimimental; provide a npy file containing an oDict in shape
+        #(order,peakNumber,300) where the final dimension is the y values 
+        #For an evenly sampled peak profile for each peak
+        LSF_MODEL_ET = np.load('EtalonPeakProfiles.npy',allow_pickle=1)[()]
         pixels = np.linspace(-6,6,300)
-        lsf = LSF_MODEL_CAL_ET[echelle_order][peakNum]
+        lsf = LSF_MODEL_ET[echelle_order][peakNum]
     else:
         raise ValueError('Invalid instrument source')
     if numPix:
@@ -329,7 +358,17 @@ def fitProfile(inp_x, inp_y, fit_center_in, order, fit_width=8, sigma=None,
         Output the fit residuals (the default is False)
     p0 : list of first-guess coefficients. The fit can be quite sensitive to these
         choices.
-    bounds : Directly sent to scipy.optimize.curve_fit()
+    bounds : 2D Sequence
+        Directly sent to scipy.optimize.curve_fit()
+    fiber : str
+        which fiber the peak comes from, does not change anything 
+        but is passed to the LSF function if enabled
+    source : str
+        what calibration source is being used, does not change 
+        anything but is paseed to LSF function if enabled
+    peakNum : int
+        which mode is being evaluated, does not change anything 
+        but is passed to the LSF funciton if enabled
 
 
     Returns

--- a/linefits/fitLib.py
+++ b/linefits/fitLib.py
@@ -14,8 +14,6 @@ import datetime
 import astropy
 import astropy.time
 from packaging import version
-import pickle
-import matplotlib.pyplot as plt
 try: #Packages needed for LSF 
     from NeidLsf import *
     import pickle

--- a/linefits/fitLib.py
+++ b/linefits/fitLib.py
@@ -14,11 +14,78 @@ import datetime
 import astropy
 import astropy.time
 from packaging import version
+import pickle
+import matplotlib.pyplot as plt
+from NeidLsf import *
 
 """ This is a library of functions that are called in the
 wavelength calibration.
 
 """
+
+def diff(x1, y1, x2, y2):
+    interp = scipy.interpolate.interp1d(x1, y1, bounds_error=False, fill_value=0)
+    y1_interp = interp(x2)
+    residuals = y1_interp - y2
+    return np.nanmean(residuals**2)
+    
+def ampAndOffset(params, xin, yin, xRef, yRef):
+    xOffset, width = params
+    xin_trans = (width * xin) + xOffset
+    interp = scipy.interpolate.interp1d(xin_trans, yin, kind='cubic', bounds_error=False, fill_value=0)
+    yRef_interp = interp(xRef)
+    residuals = yRef_interp - yRef
+    cost = np.nanmean(residuals ** 2)
+    #fig = plt.figure()
+    #plt.plot(xin_trans,yin,label='yin')
+    #plt.plot(xRef,yRef,label='yRef')
+    #plt.plot(xRef,yRef_interp,label='yInterp')
+    #plt.legend()
+    #print(f'xIn{xin_trans[0]}:{xin_trans[-1]} and xRef:{xRef[0]}:{xRef[-1]}')
+    #print(f'xOff:{params[0]}  Width:{params[1]}  Cost:{cost}')
+    return cost
+
+
+with open("NEID_LSFMODEL_HR_SCI", "rb") as f:
+    LSF_MODEL_SCI = NeidLSFModel(pickle.load(f))
+
+with open("NEID_LSFMODEL_HR_CAL", "rb") as f:
+    LSF_MODEL_CAL = NeidLSFModel(pickle.load(f))
+
+
+LSF_MODEL_CAL_ET = np.load('EtalonPeakProfilesCal.npy',allow_pickle=1)[()]
+
+
+def getLsf(echelle_order, pixel_idx, numPix=0,fiber='CAL',src = 'LFC',peakNum = 0): 
+    if src == 'LFC':
+        if(fiber == 'SCI'):
+            pixels, lsf = LSF_MODEL_SCI.lsf_model(echelle_order, pixel_idx)
+        elif(fiber=='CAL'):
+            pixels, lsf = LSF_MODEL_CAL.lsf_model(echelle_order, pixel_idx)
+
+    elif (src == 'Etalon'):
+        pixels = np.linspace(-6,6,300)
+        lsf = LSF_MODEL_CAL_ET[echelle_order][peakNum]
+    else:
+        raise ValueError('Invalid instrument source')
+    if numPix:
+        # Generate a new pixel grid linearly spaced between min and max of the original
+        pixel_min, pixel_max = pixels[0], pixels[-1]
+        pixels_new = np.linspace(pixel_min, pixel_max, numPix)
+        
+        # Interpolate LSF to the new pixel grid
+        interp_lsf = scipy.interpolate.interp1d(pixels, lsf, kind='cubic', bounds_error=False, fill_value=0)
+        lsf_new = interp_lsf(pixels_new)
+        
+        pixels = pixels_new
+        lsf = lsf_new
+
+    # Normalize
+    lsf = np.array(lsf) / np.max(lsf)
+    
+    return np.array(pixels), lsf
+
+            
 
 
 def fgauss(x, center, sigma, amp):
@@ -236,8 +303,8 @@ def rescale(x, oldmin, oldmax, newmin, newmax):
 
 
 
-def fitProfile(inp_x, inp_y, fit_center_in, fit_width=8, sigma=None,
-               func='fgauss_const', return_residuals=False,p0=None,bounds=(-np.inf,np.inf)):
+def fitProfile(inp_x, inp_y, fit_center_in, order, fit_width=8, sigma=None,
+               func='LSF', return_residuals=False,p0=None,bounds=(-np.inf,np.inf),fiber='CAL',source='LFC',peakNum=0):
     """Perform a least-squares fit to a peak-like function.
 
     Parameters
@@ -283,18 +350,40 @@ def fitProfile(inp_x, inp_y, fit_center_in, fit_width=8, sigma=None,
     """
 
     # select out the region to fit
-    # this will be only consistent to +- integer pixels
+    # this will be only consistent to +- integer pixels 
     fit_center = copy.copy(fit_center_in)
     xx_index = np.arange(len(inp_x))
     assert len(inp_x) == len(inp_y)
+    try:
+        j1 = int(np.round(np.amax([0, fit_center - fit_width])))
+        j2 = int(round(np.amin([np.amax(xx_index), fit_center + fit_width])))
+    except:
+        retval = {'centroid': np.nan,
+              'e_centroid': np.nan,
+              'sigma': np.nan,
+              'e_sigma': np.nan,
+              'nanflag': np.nan,
+              'pcov': np.nan,
+              'popt': np.nan,
+              'indices_used': (np.nan, np.nan),
+              'function_used': np.nan,
+              'tot_counts_in_line': np.nan,
+              'fit_successful': np.nan,
+              'scale_value':np.nan}
+        if return_residuals:
+            if fit_successful:
+                predicted = np.nan
+                residuals = np.nan
+            else:
+                residuals = np.nan
+            retval['residuals'] = residuals
     
-    j1 = int(np.round(np.amax([0, fit_center - fit_width])))
-    j2 = int(round(np.amin([np.amax(xx_index), fit_center + fit_width])))
+        #return(retval['popt'][0], retval['popt'][1], retval['popt'][2], retval)
+        return(retval)
 
     # define sub-arrays to fit
     sub_x1 = inp_x[j1:j2]
     sub_y1 = inp_y[j1:j2]
-
     tot_counts_in_line = float(np.nansum(sub_y1))
 
     # normalize the sub-array
@@ -307,6 +396,8 @@ def fitProfile(inp_x, inp_y, fit_center_in, fit_width=8, sigma=None,
     # select out the finite elements
     ii_good = np.isfinite(sub_y_norm1)
     sub_x = sub_x1[ii_good]
+    if len(sub_x) < 2:
+        raise Exception('fitting Err')
     sub_y_norm = sub_y_norm1[ii_good]
     if sigma is not None:
         sub_sigma1 = sigma[j1:j2]
@@ -343,10 +434,86 @@ def fitProfile(inp_x, inp_y, fit_center_in, fit_width=8, sigma=None,
         if p0 is None:
             p0 = (np.mean(sub_x),1., -np.ptp(sub_y_norm))
         use_function = fgauss_from_1
+    elif func == 'LSF':
+        if p0 == None:
+            p0 = (int(fit_center_in)+1,1)
     else:
+        print(func)
         raise ValueError
 
     # perform the least squares fit
+    if func == 'LSF':
+       
+        # Run minimization
+        bounds = ((p0[0]-3,p0[0]+3),(0.8,1.2))
+
+        xRef = sub_x
+        # Template LSF shape
+        xin,yin = getLsf(order, int(fit_center_in), 100,fiber,source,peakNum)
+        yRef = sub_y_norm
+        yin = np.array(yin)
+        yin -= np.min(yin)
+        yin /= np.max(yin)
+        yRef -= np.min(yRef)
+        yRef /= np.max(yRef)
+        # Fit model to data
+        def cost_fn(params):
+            return ampAndOffset(params, xin, yin, xRef, yRef)
+
+        result = scipy.optimize.minimize(cost_fn,
+                                         x0=p0,
+                                         method='Powell',
+                                         bounds=bounds)
+        popt = result.x
+        fit_successful = result.success
+        
+        # Apply best-fit transform
+        xin_trans = (popt[1]*xin) + popt[0]
+        yin_trans = yin
+        interp = scipy.interpolate.interp1d(xRef, yRef, kind='cubic', bounds_error=False, fill_value=0)
+        #yRef_interp = interp(xin_trans)
+        yRef_interp = np.interp(xin_trans,xRef,yRef)
+        # Compute residuals and SNR
+        residuals = yin_trans - yRef_interp
+        resid_std = np.nanstd(residuals)
+        snr_est = 1 / resid_std if resid_std > 0 else np.nan
+        
+        # Estimate effective width in pixels
+        template_area = np.nansum(yin)
+        template_peak = np.nanmax(yin)
+        effective_width_pix = template_area / template_peak if template_peak > 0 else np.nan
+        
+        # Estimate number of pixels contributing meaningfully
+        above_thresh = np.abs(yin) > 0.05 * template_peak
+        neff = np.sum(above_thresh)
+        neff = max(neff, 1)
+        
+        # Estimate centroid precision from SNR
+        centroid_error = effective_width_pix / (snr_est * np.sqrt(neff))
+        
+        # Result values
+        centroid = popt[0]
+        
+        retval = {
+            'centroid': centroid,
+            'e_centroid': centroid_error,
+            'sigma': popt[1],  # Just a placeholder if needed
+            'e_sigma': np.nan,
+            'nanflag': nanflag,
+            'pcov': None,
+            'popt': popt.tolist(),
+            'indices_used': (j1, j2),
+            'function_used': func,
+            'tot_counts_in_line': tot_counts_in_line,
+            'fit_successful': fit_successful,
+            'scale_value': float(popt[0]),
+            'snr_peak': snr_est
+        }
+        
+        if return_residuals:
+            retval['residuals'] = residuals.tolist()
+
+        return retval
     try:
         popt, pcov = scipy.optimize.curve_fit(use_function,
                                               sub_x,
@@ -484,8 +651,8 @@ def subtract_Continuum_fromlines(inputspec,refspec=None,thresh_mask=None,thresh_
     return outspec, Continuum, ThresholdMask
 
 
-def fit_lines_order(xx,fl,peak_locs,sigma=None,wl=None,pix_to_wvl=None,pix_to_wvl_per_pix=None,fitfunction='fgauss_const',
-                    fit_width_pix=8,basic_window_check=True):
+def fit_lines_order(xx,fl,peak_locs,order,sigma=None,wl=None,pix_to_wvl=None,pix_to_wvl_per_pix=None,fitfunction='LSF',
+                    fit_width_pix=8,basic_window_check=True,fiber='CAL',src='LFC'):
     """ Fit all peaks in an order
 
     This is a wrapper for the fitProfile function to do the (often used) task of repeated fitting of many lines
@@ -557,13 +724,15 @@ def fit_lines_order(xx,fl,peak_locs,sigma=None,wl=None,pix_to_wvl=None,pix_to_wv
             p0 = [loc_this,2.5,1.,0.,0.]
         elif fitfunction == 'fgauss':
             p0 = [loc_this,2.1,1.]
+        elif fitfunction == 'LSF':
+            p0 = None
         else:
             raise ValueError
         
         try:
-            tmp = fitProfile(xx,fl,loc_this,fit_width=fit_width_pix,sigma=sigma,
-                                                    func=fitfunction,p0=p0)
-        except (RuntimeError, ValueError, RuntimeWarning) as e:
+            tmp = fitProfile(xx,fl,loc_this,order,fit_width=fit_width_pix,sigma=sigma,
+                                                    func=fitfunction,p0=p0,fiber = fiber,source=src,peakNum=mi)
+        except (RuntimeError, ValueError, RuntimeWarning, Exception) as e:
             tmp = OrderedDict()
             tmp['fit_successful'] = False
             tmp['sigma'] = np.NaN
@@ -576,8 +745,9 @@ def fit_lines_order(xx,fl,peak_locs,sigma=None,wl=None,pix_to_wvl=None,pix_to_wv
 
         if basic_window_check:
             check_val = np.abs(loc_this - float(centroid_pix))
+            
             if check_val > fit_width_pix:
-                centroid_pix = np.nan
+                #centroid_pix = np.nan
                 tmp['fit_successful'] = False
 
         if wl is not None:
@@ -597,7 +767,6 @@ def fit_lines_order(xx,fl,peak_locs,sigma=None,wl=None,pix_to_wvl=None,pix_to_wv
             fwhm_wl = np.NaN
             fwhm_vel = np.NaN
             peak_counts = np.NaN
-
         out1 = OrderedDict()
         out1['fit_output'] = tmp
         out1['centroid_pix'] = centroid_pix
@@ -606,7 +775,6 @@ def fit_lines_order(xx,fl,peak_locs,sigma=None,wl=None,pix_to_wvl=None,pix_to_wv
         out1['fwhm_wl'] = fwhm_wl
         out1['snr_peak'] = np.sqrt(peak_counts)
         out1['prec_est'] = 0.4 * fwhm_vel / (np.sqrt(fwhm_pix) * np.sqrt(peak_counts))
-
         #print(mi)
         #if mi == 89:
         #    print(out1)

--- a/linefits/linefits_singleepoch.py
+++ b/linefits/linefits_singleepoch.py
@@ -1,7 +1,7 @@
 #import hpfspec2
 # this version is modified with ability to treat the reference LFC and Etalon files in the same way
 # (in NEID, the LFC mode index file is used to id the modes, but this is not needed)
-from linefits import fitLib
+import fitLib
 import sys
 import os
 import numpy as np 
@@ -136,7 +136,7 @@ def pool_measure_centroids_order(cmdset):
         #                              basic_window_check=cmdset['basic_window_check'])
     return out
 
-def measure_centroids_order(xx_pix, flux, window_centers, Config, variance=None, return_full=False):
+def measure_centroids_order(xx_pix, flux, window_centers, order, Config, variance=None, return_full=False):
     """ Measure the centroids of all lines in an order.
     
     Using a naive approach (same simple function for each line, weighted least squares,
@@ -176,9 +176,8 @@ def measure_centroids_order(xx_pix, flux, window_centers, Config, variance=None,
 
     #xx_pix = np.arange(n_pixels)
     assert len(xx) == len(flux)
-
-    out = fitLib.fit_lines_order(xx_pix,flux,window_centers,sigma=sigma,fitfunction=fit_function,
-                                     fit_width_pix=fit_width,basic_window_check=True)
+    out = fitLib.fit_lines_order(xx_pix,flux,window_centers,order,sigma=sigma,fitfunction=fit_function,
+                                     fit_width_pix=fit_width,basic_window_check=True,fiber=Config['fiber'],src=Config['source'])
 
     assert len(window_centers) == len(out)
 
@@ -263,9 +262,8 @@ def measure_and_save_linefits(filename,fiber,Config): #deleted outdir = None
             sigma = np.sqrt(var)
         else:
             sigma = None
-        
-        out_all[order] = fitLib.fit_lines_order(xx_pix,flux,initial_peak_locs_pix[order],sigma=sigma,
-            fitfunction=fit_function,fit_width_pix=fit_width,basic_window_check=True,wl=wave)
+        out_all[order] = fitLib.fit_lines_order(xx_pix,flux,initial_peak_locs_pix[order],order,sigma=sigma,
+            fitfunction=fit_function,fit_width_pix=fit_width,basic_window_check=True,wl=wave,fiber=Config['fiber'],src=Config['source'])
         # if desired to peel out a subset of parameters, could copy over the measure_centroids wrapper
 
         out_all_slim_order = OrderedDict()
@@ -375,7 +373,6 @@ def main(raw_args=None):
     fibername = Config['fiber']
     for file in filesToMeasure:
         cmdset.append({'fiber':fibername,'filename':file,'Config':Config}) #deleted 'outdir':outdir
-
     out_all = list(pmap(pool_measure_and_save_linefits,cmdset))
 
 


### PR DESCRIPTION
Added implementation for NEID Line Spread Function fitting via the model provided by AshutoshJoshiTIFR. 
Config file paramater `fitfunction` now accepts the value `LSF` which will make Linefits generate the line profile predicted by the Line Spread Function  at each echelle order and approximate peak pixel location, and fits that shape insead of fitting a Gaussian. 

Further, because the machinery is now in place to fit custom line profiles, if the `source` value in config is set to `Etalon` and LSF is enabled, the program will look for a dictionary of peak profiles called 'PeakProfiles.npy' to fit that correspond to the mode indexing in the master peak location file. This might be useful to test or implement any other set of peak profiles in the future. 